### PR TITLE
fix: temporarly remove debug logging

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -21,9 +21,12 @@ client.scheduledEvents = new Collection();
 
 // Initialize logger
 client.logger = await initLogger(client.config.loggingLibraryPlugin);
-client.on(Events.Debug, (message) => {
-	client.logger.debug(message);
-});
+
+// Disabled for now as Pino is not respecting log levels in transports
+// atm.
+// client.on(Events.Debug, (message) => {
+// 	client.logger.debug(message);
+// });
 client.on(Events.Warn, (message) => {
 	client.logger.warn(message);
 });


### PR DESCRIPTION
Somtime between pino 9.0.0 and current transport target level is being ignored.

This is a temporary fix until then, as debug is really not that usefull